### PR TITLE
Fix bug with response code && Add the 50002 error message

### DIFF
--- a/Controller/PaymillController.php
+++ b/Controller/PaymillController.php
@@ -33,6 +33,7 @@ abstract class PaymillController extends Controller
         40403 => "Currency not allowed.",
         50000 => "General problem with backend.",
         50001 => "Country blacklisted.",
+        50002 => "IP address blacklisted.",
         50100 => "Technical error with credit card.",
         50101 => "Error limit exceeded.",
         50102 => "Card declined by authorization system.",
@@ -104,7 +105,8 @@ abstract class PaymillController extends Controller
             );
 
             // We might have a better error message
-            $responseCode = $result->getFinancialTransaction()->getResponseCode();
+            $responseCode = $result->getFinancialTransaction()->getReasonCode();
+            $response['code'] = $responseCode;
             if (null !== $responseCode && isset($this->errorMessages[$responseCode])) {
                 $response['message'] = $this->errorMessages[$responseCode];
             }

--- a/Plugin/PaymillPlugin.php
+++ b/Plugin/PaymillPlugin.php
@@ -43,8 +43,8 @@ class PaymillPlugin extends AbstractPlugin
         } catch (PaymillException $e) {
             $ex = new FinancialException($e->getErrorMessage());
             $ex->setFinancialTransaction($transaction);
-            $transaction->setResponseCode($e->getResponseCode());
-            $transaction->setReasonCode($e->getStatusCode());
+            $transaction->setResponseCode($e->getStatusCode());
+            $transaction->setReasonCode($e->getResponseCode());
             throw $ex;
         }
 
@@ -58,16 +58,18 @@ class PaymillPlugin extends AbstractPlugin
 
             case 'open':
             case 'pending':
+                $ex = new PaymentPendingException('Payment is still pending');
                 $transaction->setReferenceNumber($apiTransaction->getId());
                 $transaction->setResponseCode(PluginInterface::RESPONSE_CODE_PENDING);
                 $transaction->setReasonCode(PluginInterface::REASON_CODE_SUCCESS);
-                throw new PaymentPendingException('Payment is still pending');
+                $ex->setFinancialTransaction($transaction);
+                throw $ex;
 
             default:
                 $ex = new FinancialException('Transaction failed');
                 $ex->setFinancialTransaction($transaction);
                 $transaction->setResponseCode('Failed');
-                $transaction->setReasonCode($apiTransaction->getStatus());
+                $transaction->setReasonCode($apiTransaction->getResponseCode());
                 throw $ex;
         }
     }


### PR DESCRIPTION
Paymill response code is JMS reason code (see [paymill
tests](https://github.com/paymill/paymill-php/blob/2eefd630f014c2ece9857bf0ba3fd920deb52208/tests/unit/Paymill/Services/ResponseHandlerTest.php#L621-L653)). The `status` is JMS response code.

This lead to a standard message `an error has occured` or something
like that  but no detail.

The financial transaction was missing when the transaction was pending
