### PR TITLE
Removed use of deprecated function

### DIFF
--- a/Controller/WebhooksController.php
+++ b/Controller/WebhooksController.php
@@ -44,7 +44,7 @@ class WebhooksController extends Controller
         $eventType = $event['event_type'];
 
         if (!in_array($eventType, $this->supportedEvents)) {
-            $log->warn("Unsupported event type $eventType. Ignoring.");
+            $log->warning("Unsupported event type $eventType. Ignoring.");
             return $response;
         }
 


### PR DESCRIPTION
We should use `warning` instead of `warn` to be PSR-3 compliant. This function will be removed in symfony/monolog-bridge: 3.0
