### PR TITLE
Allow to pass options to getPaymillForm method

### DIFF
--- a/Controller/PaymillController.php
+++ b/Controller/PaymillController.php
@@ -11,17 +11,19 @@ use JMS\Payment\CoreBundle\PluginController\Result;
 
 abstract class PaymillController extends Controller
 {
-    protected function getPaymillForm($amount, $currency, $options = array())
+    protected function getPaymillForm($amount, $currency, $data = array(), $options = array())
     {
-        return $this->get('form.factory')->create('jms_choose_payment_method', null, array(
+        $options = array_merge(array(
             'allowed_methods' => array('paymill'),
             'default_method'  => 'paymill',
             'amount'          => $amount,
             'currency'        => $currency,
             'predefined_data' => array(
-                'paymill' => $options
-            ),
-        ));
+                'paymill' => $data,
+            )
+        ), $options);
+
+        return $this->get('form.factory')->create('jms_choose_payment_method', null, $options);
     }
 
     /**
@@ -51,7 +53,7 @@ abstract class PaymillController extends Controller
      *
      * @return JsonResponse
      */
-    protected function completePayment(PaymentInstructionInterface $instruction, $route, $routeParams)
+    protected function completePayment(PaymentInstructionInterface $instruction, $route, $routeParams = array())
     {
         $ppc        = $this->get('payment.plugin_controller');
         $translator = $this->get('translator');


### PR DESCRIPTION
This PR allows to pass custom options when calling getPaymillForm(). Exemple :

```
$this->getPaymillForm($amount, $currency, array('intention' => 'payment'), array('email' => $user->getEmail()));
```

This breaks BC as the paymill data array is now in third position.

I also add an empty array as default route parameters in the completePayment method.
